### PR TITLE
Add edt to group 1 and group 2

### DIFF
--- a/cybot/__main__.py
+++ b/cybot/__main__.py
@@ -17,11 +17,11 @@ class Celcat(commands.Cog[commands.Context]):
         self.bot = bot
 
     @commands.command()
-    async def edt(self, ctx: commands.Context, date: Optional[str] = None) -> None:
+    async def edt(self, ctx: commands.Context, group: int = 1, date: Optional[str] = None) -> None:
         logging.info(f"{ctx.author} asked for edt")
         if date is None:
             c = Calendar()
-            c.fetch()
+            c.fetch(group)
             await ctx.send(f"```\n{c.next_course()}\n```")
         else:
             try:
@@ -31,7 +31,7 @@ class Celcat(commands.Cog[commands.Context]):
                 return
 
             c = Calendar(d)
-            c.fetch()
+            c.fetch(group)
 
             s = "\n\n".join([str(e) for e in c.courses if e.start.date() == d.date()])
             await ctx.send(f"```\n{s}\n```")

--- a/cybot/celcat.py
+++ b/cybot/celcat.py
@@ -49,7 +49,7 @@ class Calendar:
         self.end = self.start.shift(weeks=+1) if end is None else end
         self.courses: List[Course] = []
 
-    def fetch(self) -> None:
+    def fetch(self, group: int) -> None:
         s = requests.Session()
         rlt = s.get("https://services-web.u-cergy.fr/calendar/LdapLogin")
         if srvt := re.search(
@@ -68,7 +68,7 @@ class Calendar:
                 "__RequestVerificationToken": rvt,
             },
         )
-        fid = parse_qs(rlogin.url)["FederationIds"][0]
+        fid = cfg["celcat"][f"group{group}"]
         rcd = s.post(
             "https://services-web.u-cergy.fr/calendar/Home/GetCalendarData",
             data={


### PR DESCRIPTION
Quick fix to add edt fetch for group 1 & 2, by using comand: `:edt 1 ...` or `edt 2 ...`

Note: You need to add in your `secrets.json`:

```json
"celcat": {
   ...
   "group1": "id of a member of group 1",
   "group2": "id of a member of group 2"
}
```